### PR TITLE
Revert "Makes tags optional so you can use default_tags (Fixes: Error: "tags" are identical to those in the "default_tags" configuration block of the provider: please de-duplicate and try again" Discussed it is better to set the tags to null when using this module

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | name | The name of the bucket | `string` | n/a | yes |
+| tags | A mapping of tags to assign to the bucket | `map(string)` | n/a | yes |
 | acl | The canned ACL to apply, defaults to `private` | `string` | `"private"` | no |
 | block\_public\_acls | Whether Amazon S3 should block public ACLs for this bucket | `bool` | `true` | no |
 | block\_public\_policy | Whether Amazon S3 should block public bucket policies for this bucket | `bool` | `true` | no |
@@ -33,7 +34,6 @@
 | policy | A valid bucket policy JSON document | `string` | `null` | no |
 | replication\_configuration | Bucket replication configuration settings | <pre>object({<br>    iam_role_arn       = string<br>    dest_bucket        = string<br>    dest_storage_class = string<br>    rule_id            = string<br>  })</pre> | `null` | no |
 | restrict\_public\_buckets | Whether Amazon S3 should restrict public bucket policies for this bucket | `bool` | `true` | no |
-| tags | A mapping of tags to assign to the bucket | `map(string)` | `null` | no |
 | versioning | Versioning is a means of keeping multiple variants of an object in the same bucket | `bool` | `false` | no |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -115,6 +115,5 @@ variable "versioning" {
 
 variable "tags" {
   type        = map(string)
-  default     = null
   description = "A mapping of tags to assign to the bucket"
 }


### PR DESCRIPTION
This reverts commit e49dc31ce98e74788e3933eeaf37ce28b4e28941.