### PR TITLE
Enforce S3 Access logging to be always enabled

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -64,4 +64,4 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v3.0.0
+        uses: triat/terraform-security-scan@v3.0.1

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 | ignore\_public\_acls | Whether Amazon S3 should ignore public ACLs for this bucket | `bool` | `true` | no |
 | kms\_key\_id | The KMS key ID used for the bucket encryption | `string` | `null` | no |
 | lifecycle\_rule | List of maps containing lifecycle management configuration settings | `any` | `[]` | no |
-| logging | Logging configuration. Default is logging in the bucket itelf | <pre>object({<br>    target_bucket = string<br>    target_prefix = string<br>  })</pre> | <pre>{<br>  "target_bucket": null,<br>  "target_prefix": "s3_access_logs"<br>}</pre> | no |
+| logging | Logging configuration, defaults to logging to the bucket itself | <pre>object({<br>    target_bucket = string<br>    target_prefix = string<br>  })</pre> | <pre>{<br>  "target_bucket": null,<br>  "target_prefix": "s3_access_logs"<br>}</pre> | no |
 | object\_lock\_days | The number of days that you want to specify for the default retention period | `number` | `null` | no |
 | object\_lock\_mode | The default object Lock retention mode to apply to new objects | `string` | `null` | no |
 | object\_lock\_years | The number of years that you want to specify for the default retention period | `number` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 | ignore\_public\_acls | Whether Amazon S3 should ignore public ACLs for this bucket | `bool` | `true` | no |
 | kms\_key\_id | The KMS key ID used for the bucket encryption | `string` | `null` | no |
 | lifecycle\_rule | List of maps containing lifecycle management configuration settings | `any` | `[]` | no |
-| logging | Logging configuration | <pre>object({<br>    target_bucket = string<br>    target_prefix = string<br>  })</pre> | `null` | no |
+| logging | Logging configuration. Default is logging in the bucket itelf | <pre>object({<br>    target_bucket = string<br>    target_prefix = string<br>  })</pre> | <pre>{<br>  "target_bucket": null,<br>  "target_prefix": "s3_access_logs"<br>}</pre> | no |
 | object\_lock\_days | The number of days that you want to specify for the default retention period | `number` | `null` | no |
 | object\_lock\_mode | The default object Lock retention mode to apply to new objects | `string` | `null` | no |
 | object\_lock\_years | The number of years that you want to specify for the default retention period | `number` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
+| aws | < 4.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | < 4.0.0 |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,9 @@
 locals {
   bucket_key_enabled        = var.kms_key_id != null ? true : false
   cors_rule                 = var.cors_rule != null ? { create = true } : {}
+  logging                   = var.logging != null ? { create = true } : {}
   logging_permissions       = try(var.logging.target_bucket == null, false) ? { create = true } : {}
   replication_configuration = var.replication_configuration != null ? { create = true } : {}
-  logging                   = var.logging != null ? { create = true } : {}
 }
 
 data "aws_iam_policy_document" "bucket_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -66,7 +66,7 @@ variable "logging" {
     target_bucket = null
     target_prefix = "s3_access_logs"
   }
-  description = "Logging configuration. Default is logging in the bucket itelf"
+  description = "Logging configuration, defaults to logging to the bucket itself"
 }
 
 variable "object_lock_mode" {

--- a/variables.tf
+++ b/variables.tf
@@ -62,8 +62,11 @@ variable "logging" {
     target_bucket = string
     target_prefix = string
   })
-  default     = null
-  description = "Logging configuration"
+  default = {
+    target_bucket = null
+    target_prefix = "s3_access_logs"
+  }
+  description = "Logging configuration. Default is logging in the bucket itelf"
 }
 
 variable "object_lock_mode" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "< 4.0.0"
     }
   }
 


### PR DESCRIPTION
This PR changes the access logs to be always enabled, if no logging bucket is specified, it will log to the bucket itself.

**Reason:**
AWS Securityhub added a `medium` level finding on this settings ([Announcement](https://aws.amazon.com/about-aws/whats-new/2022/02/aws-security-hub-new-controls-partners-automated-security-posture-monitoring/), [Security hub documentation](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#s3-9)).

This could always be configured already, but with this change the bucket itself will be used to store the logs (using the `s3_access_logs`) and the required additional bucket policies are added.

As a result logging will always be enabled, either by specifying a bucket (for a more centralized logging) or in the bucket itself.

Also had to pin the provider version to `< 4` due to the huge refactoring they did in the S3 bucket, current code is not compatible with the new AWS provider anymore. Will refactor that in a different PR