### PR TITLE
Refactor object_lock configuration

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -64,4 +64,4 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v3.0.1
+        uses: triat/terraform-security-scan@v3.0.3


### PR DESCRIPTION
This PR refactors the object_lock configuration, resolves the `Warning: Argument is deprecated` with 
`Use the top-level parameter object_lock_enabled and the aws_s3_bucket_object_lock_configuration resource instead`

See also: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#using-object-lock-configuration
