### PR TITLE
up versions to v4.9.0 to prevent issues with upgrading

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0 |
-| aws | >= 4.0.0 |
+| aws | >= 4.9.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 4.0.0 |
+| aws | >= 4.9.0 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0.0"
+      version = ">= 4.9.0"
     }
   }
 


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#changes-to-s3-bucket-drift-detection