### PR TITLE
Feat: Provide Object Ownership Enforcement option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,10 @@
 | cors\_rule | The CORS rule for the S3 bucket | <pre>object({<br>    allowed_headers = list(string)<br>    allowed_methods = list(string)<br>    allowed_origins = list(string)<br>    expose_headers  = list(string)<br>    max_age_seconds = number<br>  })</pre> | `null` | no |
 | force\_destroy | A boolean that indicates all objects should be deleted when deleting the bucket | `bool` | `false` | no |
 | ignore\_public\_acls | Whether Amazon S3 should ignore public ACLs for this bucket | `bool` | `true` | no |
-| is\_acl\_enabled | Whether ACLs should be enabled for S3 buckets | `bool` | `true` | no |
-| is\_bucket\_ownership\_enforced | Whether BucketOwnerEnforced object ownership is applied | `bool` | `false` | no |
 | kms\_key\_arn | The KMS key ARN used for the bucket encryption | `string` | `null` | no |
 | lifecycle\_rule | List of maps containing lifecycle management configuration settings | `any` | `[]` | no |
 | logging | Logging configuration, defaults to logging to the bucket itself | <pre>object({<br>    target_bucket = string<br>    target_prefix = string<br>  })</pre> | <pre>{<br>  "target_bucket": null,<br>  "target_prefix": "s3_access_logs/"<br>}</pre> | no |
+| object\_ownership\_type | Type of object ownership within S3 bucket | `string` | `ObjectWriter` | no |
 | object\_lock\_days | The number of days that you want to specify for the default retention period | `number` | `null` | no |
 | object\_lock\_mode | The default object Lock retention mode to apply to new objects | `string` | `null` | no |
 | object\_lock\_years | The number of years that you want to specify for the default retention period | `number` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 | cors\_rule | The CORS rule for the S3 bucket | <pre>object({<br>    allowed_headers = list(string)<br>    allowed_methods = list(string)<br>    allowed_origins = list(string)<br>    expose_headers  = list(string)<br>    max_age_seconds = number<br>  })</pre> | `null` | no |
 | force\_destroy | A boolean that indicates all objects should be deleted when deleting the bucket | `bool` | `false` | no |
 | ignore\_public\_acls | Whether Amazon S3 should ignore public ACLs for this bucket | `bool` | `true` | no |
+| is\_acl\_enabled | Whether Amazon S3 should enable ACLs for this bucket | `bool` | `true` | no |
 | kms\_key\_arn | The KMS key ARN used for the bucket encryption | `string` | `null` | no |
 | lifecycle\_rule | List of maps containing lifecycle management configuration settings | `any` | `[]` | no |
 | logging | Logging configuration, defaults to logging to the bucket itself | <pre>object({<br>    target_bucket = string<br>    target_prefix = string<br>  })</pre> | <pre>{<br>  "target_bucket": null,<br>  "target_prefix": "s3_access_logs/"<br>}</pre> | no |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 | cors\_rule | The CORS rule for the S3 bucket | <pre>object({<br>    allowed_headers = list(string)<br>    allowed_methods = list(string)<br>    allowed_origins = list(string)<br>    expose_headers  = list(string)<br>    max_age_seconds = number<br>  })</pre> | `null` | no |
 | force\_destroy | A boolean that indicates all objects should be deleted when deleting the bucket | `bool` | `false` | no |
 | ignore\_public\_acls | Whether Amazon S3 should ignore public ACLs for this bucket | `bool` | `true` | no |
-| is\_acl\_enabled | Whether Amazon S3 should enable ACLs for this bucket | `bool` | `true` | no |
+| is\_bucket\_ownership\_enforced | Whether ACLs should be disabled for S3 bucket and BucketOwnerEnforced object ownership is applied | `bool` | `true` | no |
 | kms\_key\_arn | The KMS key ARN used for the bucket encryption | `string` | `null` | no |
 | lifecycle\_rule | List of maps containing lifecycle management configuration settings | `any` | `[]` | no |
 | logging | Logging configuration, defaults to logging to the bucket itself | <pre>object({<br>    target_bucket = string<br>    target_prefix = string<br>  })</pre> | <pre>{<br>  "target_bucket": null,<br>  "target_prefix": "s3_access_logs/"<br>}</pre> | no |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 | cors\_rule | The CORS rule for the S3 bucket | <pre>object({<br>    allowed_headers = list(string)<br>    allowed_methods = list(string)<br>    allowed_origins = list(string)<br>    expose_headers  = list(string)<br>    max_age_seconds = number<br>  })</pre> | `null` | no |
 | force\_destroy | A boolean that indicates all objects should be deleted when deleting the bucket | `bool` | `false` | no |
 | ignore\_public\_acls | Whether Amazon S3 should ignore public ACLs for this bucket | `bool` | `true` | no |
-| is\_bucket\_ownership\_enforced | Whether ACLs should be disabled for S3 bucket and BucketOwnerEnforced object ownership is applied | `bool` | `true` | no |
+| is\_bucket\_ownership\_enforced | Whether ACLs should be disabled for S3 bucket and BucketOwnerEnforced object ownership is applied | `bool` | `false` | no |
 | kms\_key\_arn | The KMS key ARN used for the bucket encryption | `string` | `null` | no |
 | lifecycle\_rule | List of maps containing lifecycle management configuration settings | `any` | `[]` | no |
 | logging | Logging configuration, defaults to logging to the bucket itself | <pre>object({<br>    target_bucket = string<br>    target_prefix = string<br>  })</pre> | <pre>{<br>  "target_bucket": null,<br>  "target_prefix": "s3_access_logs/"<br>}</pre> | no |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@
 | cors\_rule | The CORS rule for the S3 bucket | <pre>object({<br>    allowed_headers = list(string)<br>    allowed_methods = list(string)<br>    allowed_origins = list(string)<br>    expose_headers  = list(string)<br>    max_age_seconds = number<br>  })</pre> | `null` | no |
 | force\_destroy | A boolean that indicates all objects should be deleted when deleting the bucket | `bool` | `false` | no |
 | ignore\_public\_acls | Whether Amazon S3 should ignore public ACLs for this bucket | `bool` | `true` | no |
-| is\_bucket\_ownership\_enforced | Whether ACLs should be disabled for S3 bucket and BucketOwnerEnforced object ownership is applied | `bool` | `false` | no |
+| is\_acl\_enabled | Whether ACLs should be enabled for S3 buckets | `bool` | `true` | no |
+| is\_bucket\_ownership\_enforced | Whether BucketOwnerEnforced object ownership is applied | `bool` | `false` | no |
 | kms\_key\_arn | The KMS key ARN used for the bucket encryption | `string` | `null` | no |
 | lifecycle\_rule | List of maps containing lifecycle management configuration settings | `any` | `[]` | no |
 | logging | Logging configuration, defaults to logging to the bucket itself | <pre>object({<br>    target_bucket = string<br>    target_prefix = string<br>  })</pre> | <pre>{<br>  "target_bucket": null,<br>  "target_prefix": "s3_access_logs/"<br>}</pre> | no |

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,7 @@ resource "aws_s3_bucket" "default" {
 }
 
 resource "aws_s3_bucket_acl" "default" {
+  count  = var.is_acl_enabled ? 1 : 0
   bucket = aws_s3_bucket.default.id
   acl    = var.acl
 }

--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,7 @@ resource "aws_s3_bucket_acl" "default" {
 
 resource "aws_s3_bucket_ownership_controls" "default" {
   count  = var.is_bucket_ownership_enforced ? 1 : 0
+  bucket = aws_s3_bucket.default.id
   rule {
     object_ownership = "BucketOwnerEnforced"
   }

--- a/main.tf
+++ b/main.tf
@@ -57,16 +57,16 @@ resource "aws_s3_bucket" "default" {
 }
 
 resource "aws_s3_bucket_acl" "default" {
-  count  = var.is_acl_enabled ? 1 : 0
+  count  = var.object_ownership_type != "BucketOwnerEnforced" ? 1 : 0
   bucket = aws_s3_bucket.default.id
   acl    = var.acl
 }
 
 resource "aws_s3_bucket_ownership_controls" "default" {
-  count  = var.is_bucket_ownership_enforced ? 1 : 0
+  count  = var.object_ownership_type == "BucketOwnerPreferred" ? 1 : (var.object_ownership_type == "BucketOwnerEnforced" ? 1 : 0) 
   bucket = aws_s3_bucket.default.id
   rule {
-    object_ownership = "BucketOwnerEnforced"
+    object_ownership = var.object_ownership_type
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -57,9 +57,16 @@ resource "aws_s3_bucket" "default" {
 }
 
 resource "aws_s3_bucket_acl" "default" {
-  count  = var.is_acl_enabled ? 1 : 0
+  count  = var.is_bucket_ownership_enforced ? 1 : 0
   bucket = aws_s3_bucket.default.id
   acl    = var.acl
+}
+
+resource "aws_s3_bucket_ownership_controls" "default" {
+  count  = var.is_bucket_ownership_enforced ? 1 : 0
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
 }
 
 resource "aws_s3_bucket_cors_configuration" "default" {

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "aws_s3_bucket" "default" {
 }
 
 resource "aws_s3_bucket_acl" "default" {
-  count  = var.is_bucket_ownership_enforced ? 1 : 0
+  count  = var.is_acl_enabled ? 1 : 0
   bucket = aws_s3_bucket.default.id
   acl    = var.acl
 }

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "aws_s3_bucket_acl" "default" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "default" {
-  count  = var.object_ownership_type == "BucketOwnerPreferred" ? 1 : (var.object_ownership_type == "BucketOwnerEnforced" ? 1 : 0) 
+  count  = var.object_ownership_type == "BucketOwnerPreferred" ? 1 : (var.object_ownership_type == "BucketOwnerEnforced" ? 1 : 0)
   bucket = aws_s3_bucket.default.id
   rule {
     object_ownership = var.object_ownership_type

--- a/variables.tf
+++ b/variables.tf
@@ -45,16 +45,10 @@ variable "ignore_public_acls" {
   description = "Whether Amazon S3 should ignore public ACLs for this bucket"
 }
 
-variable "is_acl_enabled" {
-  type        = bool
-  default     = true
-  description = "Whether ACLs should be enabled for S3 buckets"
-}
-
-variable "is_bucket_ownership_enforced" {
-  type        = bool
-  default     = false
-  description = "Whether ACLs should be disabled for S3 bucket and BucketOwnerEnforced object ownership is applied"
+variable "object_ownership_type" {
+  type        = string
+  default     = "ObjectWriter"
+  description = "The object ownership type for the objects in S3 Bucket, defaults to Object Writer "
 }
 
 variable "kms_key_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,13 @@ variable "ignore_public_acls" {
   description = "Whether Amazon S3 should ignore public ACLs for this bucket"
 }
 
+variable "is_acl_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether ACLs need to be enabled for a bucket"
+}
+
+
 variable "kms_key_arn" {
   type        = string
   default     = null

--- a/variables.tf
+++ b/variables.tf
@@ -45,12 +45,6 @@ variable "ignore_public_acls" {
   description = "Whether Amazon S3 should ignore public ACLs for this bucket"
 }
 
-variable "object_ownership_type" {
-  type        = string
-  default     = "ObjectWriter"
-  description = "The object ownership type for the objects in S3 Bucket, defaults to Object Writer "
-}
-
 variable "kms_key_arn" {
   type        = string
   default     = null
@@ -91,6 +85,12 @@ variable "object_lock_days" {
   type        = number
   default     = null
   description = "The number of days that you want to specify for the default retention period"
+}
+
+variable "object_ownership_type" {
+  type        = string
+  default     = "ObjectWriter"
+  description = "The object ownership type for the objects in S3 Bucket, defaults to Object Writer "
 }
 
 variable "replication_configuration" {

--- a/variables.tf
+++ b/variables.tf
@@ -45,12 +45,17 @@ variable "ignore_public_acls" {
   description = "Whether Amazon S3 should ignore public ACLs for this bucket"
 }
 
+variable "is_acl_enabled" {
+  type        = bool
+  default     = true
+  description = "Whether ACLs should be enabled for S3 buckets"
+}
+
 variable "is_bucket_ownership_enforced" {
   type        = bool
   default     = false
   description = "Whether ACLs should be disabled for S3 bucket and BucketOwnerEnforced object ownership is applied"
 }
-
 
 variable "kms_key_arn" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -45,10 +45,10 @@ variable "ignore_public_acls" {
   description = "Whether Amazon S3 should ignore public ACLs for this bucket"
 }
 
-variable "is_acl_enabled" {
+variable "is_bucket_ownership_enforced" {
   type        = bool
   default     = false
-  description = "Whether ACLs need to be enabled for a bucket"
+  description = "Whether ACLs should be disabled for S3 bucket and BucketOwnerEnforced object ownership is applied"
 }
 
 


### PR DESCRIPTION
- Creates variable `object_ownership_type ` to denote object ownership

Currently, using the `mcaf` module for s3 buckets creates an S3 Bucket with `Private` acl and by default `ObjectWriter` object ownership. There is no way we can ensure the ACLs are disabled when we want them. This change ensures the following -
- ACLs are not set to any value if `object_ownership_type` is equal to `BucketOwnerEnforced`
- Object Ownership is enforced or applied depending on the variable value
