### PR TITLE
fix object lock no logging config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This behaviour can be changed by modifying the `logging` variable, or server acc
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0 |
+| terraform | >= 1.2.0 |
 | aws | >= 4.9.0 |
 
 ## Providers
@@ -38,10 +38,10 @@ This behaviour can be changed by modifying the `logging` variable, or server acc
 | kms\_key\_arn | The KMS key ARN used for the bucket encryption | `string` | `null` | no |
 | lifecycle\_rule | List of maps containing lifecycle management configuration settings | `any` | `[]` | no |
 | logging | Logging configuration, defaults to logging to the bucket itself | <pre>object({<br>    target_bucket = string<br>    target_prefix = string<br>  })</pre> | <pre>{<br>  "target_bucket": null,<br>  "target_prefix": "s3_access_logs/"<br>}</pre> | no |
-| object\_ownership\_type | Type of object ownership within S3 bucket | `string` | `ObjectWriter` | no |
 | object\_lock\_days | The number of days that you want to specify for the default retention period | `number` | `null` | no |
 | object\_lock\_mode | The default object Lock retention mode to apply to new objects | `string` | `null` | no |
 | object\_lock\_years | The number of years that you want to specify for the default retention period | `number` | `null` | no |
+| object\_ownership\_type | The object ownership type for the objects in S3 Bucket, defaults to Object Writer | `string` | `"ObjectWriter"` | no |
 | policy | A valid bucket policy JSON document | `string` | `null` | no |
 | replication\_configuration | Bucket replication configuration settings | <pre>object({<br>    iam_role_arn       = string<br>    dest_bucket        = string<br>    dest_storage_class = string<br>    rule_id            = string<br>  })</pre> | `null` | no |
 | restrict\_public\_buckets | Whether Amazon S3 should restrict public bucket policies for this bucket | `bool` | `true` | no |
@@ -53,4 +53,5 @@ This behaviour can be changed by modifying the `logging` variable, or server acc
 |------|-------------|
 | arn | ARN of the bucket |
 | name | Name of the bucket |
+
 <!--- END_TF_DOCS --->

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # terraform-aws-mcaf-s3
 
+## Server access logging to the same bucket
+It's considered best practise to enable server access logging. That is why for compliance reasons we would like to have it enabled. However the default setting in this module is to log to the bucket itself. This may increase the costs as indicated by this message from AWS:
+
+>When your source bucket and target bucket are the same, additional logs are created for the logs that are written to the bucket. These extra logs can increase your storage billing and make it harder to find the logs that you're looking for.
+
+In short: we deemed compliance over costs.
+
+You can configure the bucket to send the logs another bucket by using the variable `logging`.
+
 <!--- BEGIN_TF_DOCS --->
 ## Requirements
 
@@ -44,5 +53,4 @@
 |------|-------------|
 | arn | ARN of the bucket |
 | name | Name of the bucket |
-
 <!--- END_TF_DOCS --->

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # terraform-aws-mcaf-s3
 
-## Server access logging to the same bucket
-It's considered best practise to enable server access logging. That is why for compliance reasons we would like to have it enabled. However the default setting in this module is to log to the bucket itself. This may increase the costs as indicated by this message from AWS:
+## Server access logging
 
->When your source bucket and target bucket are the same, additional logs are created for the logs that are written to the bucket. These extra logs can increase your storage billing and make it harder to find the logs that you're looking for.
+Server access logging provides detailed records for the requests that are made to a bucket and can useful in security and access audits. For this reason it is enabled by default and saves access logs to `s3_access_logs/` in the same bucket. Be aware this can increase the costs as indicated by AWS:
 
-In short: we deemed compliance over costs.
+> When your source bucket and target bucket are the same, additional logs are created for the logs that are written to the bucket. These extra logs can increase your storage billing and make it harder to find the logs that you're looking for.
 
-You can configure the bucket to send the logs another bucket by using the variable `logging`.
+This behaviour can be changed by modifying the `logging` variable, or server access logging can be disabled by setting the value to `null`.
+
 
 <!--- BEGIN_TF_DOCS --->
 ## Requirements

--- a/main.tf
+++ b/main.tf
@@ -158,6 +158,13 @@ resource "aws_s3_bucket_logging" "default" {
   bucket        = aws_s3_bucket.default.id
   target_bucket = var.logging.target_bucket == null ? var.name : var.logging.target_bucket
   target_prefix = var.logging.target_prefix
+
+  lifecycle {
+    precondition {
+      condition     = var.logging.target_bucket != null || var.object_lock_mode == null
+      error_message = "You're trying to enable logging and have object lock enabled on the same bucket! Object lock prevents server access logs from getting delivered. Either log to a different bucket by using the variable `logging` or remove the object lock configuration with `object_lock_mode == null`."
+    }
+  }
 }
 
 resource "aws_s3_bucket_object_lock_configuration" "default" {

--- a/main.tf
+++ b/main.tf
@@ -162,7 +162,7 @@ resource "aws_s3_bucket_logging" "default" {
   lifecycle {
     precondition {
       condition     = var.logging.target_bucket != null || var.object_lock_mode == null
-      error_message = "You're trying to enable logging and have object lock enabled on the same bucket! Object lock prevents server access logs from getting delivered. Either log to a different bucket by using the variable `logging` or remove the object lock configuration with `object_lock_mode == null`."
+      error_message = "You're trying to enable server access logging and object locking on the same bucket! Object lock will prevent server access logs from written to the bucket. Either log to a different bucket or remove the object lock configuration."
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
   }
 
-  required_version = ">= 0.12.0"
+  required_version = ">= 1.2.0"
 }


### PR DESCRIPTION
- Adds precondition to logging when using same bucket when object lock is enabled, as this prevents logs from being sent there
- Updates README to include remark about extra costs when logging to same bucket is configured
