### PR TITLE
Change ACL creating specification

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ resource "aws_s3_bucket" "default" {
 }
 
 resource "aws_s3_bucket_acl" "default" {
-  count  = var.object_ownership_type != "BucketOwnerEnforced" ? 1 : 0
+  count  = var.object_ownership_type == "ObjectWriter" ? 1 : 0
   bucket = aws_s3_bucket.default.id
   acl    = var.acl
 }


### PR DESCRIPTION
Change the logic on creating the ACL. As of last Friday I'm hitting the following error when creating S3 buckets:

```Error: error creating S3 bucket ACL for XXXX: AccessControlListNotSupported: The bucket does not allow ACLs status code: 400, request id: XXX, host id:=XXX```

This PR changes the ACL creation, based on the following documentation: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

```If you want to enable ACLs for a bucket, you can set the ObjectOwnership parameter to ObjectWriter in your [CreateBucket](https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateBucket.html) request or you can call [DeleteBucketOwnershipControls](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketOwnershipControls.html) after you create the bucket```