### PR TITLE
Update and simplify aws_s3_bucket_ownership_controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Source: https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-acce
 | object\_lock\_days | The number of days that you want to specify for the default retention period | `number` | `null` | no |
 | object\_lock\_mode | The default object Lock retention mode to apply to new objects | `string` | `null` | no |
 | object\_lock\_years | The number of years that you want to specify for the default retention period | `number` | `null` | no |
-| object\_ownership\_type | The object ownership type for the objects in S3 Bucket, defaults to Object Writer | `string` | `"ObjectWriter"` | no |
+| object\_ownership\_type | The object ownership type for the objects in S3 Bucket, defaults to BucketOwnerEnforced | `string` | `"BucketOwnerEnforced"` | no |
 | policy | A valid bucket policy JSON document | `string` | `null` | no |
 | replication\_configuration | Bucket replication configuration settings | <pre>object({<br>    iam_role_arn       = string<br>    dest_bucket        = string<br>    dest_storage_class = string<br>    rule_id            = string<br>  })</pre> | `null` | no |
 | restrict\_public\_buckets | Whether Amazon S3 should restrict public bucket policies for this bucket | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -77,7 +77,6 @@ resource "aws_s3_bucket_acl" "default" {
 }
 
 resource "aws_s3_bucket_ownership_controls" "default" {
-  count  = var.object_ownership_type == "BucketOwnerPreferred" ? 1 : (var.object_ownership_type == "BucketOwnerEnforced" ? 1 : 0)
   bucket = aws_s3_bucket.default.id
   rule {
     object_ownership = var.object_ownership_type

--- a/variables.tf
+++ b/variables.tf
@@ -95,8 +95,8 @@ variable "object_lock_days" {
 
 variable "object_ownership_type" {
   type        = string
-  default     = "ObjectWriter"
-  description = "The object ownership type for the objects in S3 Bucket, defaults to Object Writer "
+  default     = "BucketOwnerEnforced"
+  description = "The object ownership type for the objects in S3 Bucket, defaults to BucketOwnerEnforced"
 }
 
 variable "replication_configuration" {


### PR DESCRIPTION
As documented here: https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html

The default ownership values changed from `ObjectWriter` to `BucketOwnerEnforced`.

This PR also changes the default to this. Also removed the optional creation of the `aws_s3_bucket_ownership_controls` resource, which actually is the cause of the errors/issues that are there now: The default in code is not the default in AWS...

See also: https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/