### PR TITLE
Add support for EventBridge notifications

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -200,6 +200,13 @@ resource "aws_s3_bucket_object_lock_configuration" "default" {
   }
 }
 
+resource "aws_s3_bucket_notification" "eventbridge" {
+  count = var.eventbridge_enabled ? 1 : 0
+
+  bucket      = aws_s3_bucket.default.id
+  eventbridge = var.eventbridge_enabled
+}
+
 resource "aws_s3_bucket_replication_configuration" "default" {
   for_each = local.replication_configuration
 

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "cors_rule" {
   description = "The CORS rule for the S3 bucket"
 }
 
+variable "eventbridge_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether to enable Amazon EventBridge notifications"
+}
+
 variable "force_destroy" {
   type        = bool
   default     = false


### PR DESCRIPTION
This PR enables the EventBridge notification (if wanted). In my case want it for Triggering a CodePipeline.

Links:

- https://docs.aws.amazon.com/codepipeline/latest/userguide/update-change-detection.html#update-change-detection-S3-event
- https://registry.terraform.io/providers/hashicorp/aws/5.9.0/docs/resources/s3_bucket_notification#emit-events-to-eventbridge
- https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-event-notifications-eventbridge.html