### PR TITLE
fix: Fix error in ACL configuration

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -7,6 +7,7 @@ resource "random_pet" "default" {
 }
 
 module "log_bucket" {
+  #checkov:skip=CKV_AWS_300: false positive https://github.com/bridgecrewio/checkov/issues/5363
   source = "../.."
 
   name       = "logs-${random_pet.default.id}"

--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,8 @@ resource "aws_s3_bucket_acl" "default" {
   count  = var.object_ownership_type == "ObjectWriter" ? 1 : 0
   bucket = aws_s3_bucket.default.id
   acl    = var.acl
+
+  depends_on = [aws_s3_bucket_ownership_controls.default]
 }
 
 resource "aws_s3_bucket_ownership_controls" "default" {


### PR DESCRIPTION
This PR fixes a bug when deploying a bucket with specific ACL settings:

```hcl
module "my_bucket" {
  source                = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.10.0"
  object_ownership_type = "ObjectWriter"
  acl                   = "log-delivery-write"
```

With these settings, the `object_ownership_type` has to be set before the ACL can be applied. Currently the first TF run fails:

`Error: creating S3 bucket ACL for XXX: AccessControlListNotSupported: The bucket does not allow ACLs status`

Second run is succesful.