### PR TITLE
enhancement: remove logging in own bucket more explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ No modules.
 | <a name="input_ignore_public_acls"></a> [ignore\_public\_acls](#input\_ignore\_public\_acls) | Whether Amazon S3 should ignore public ACLs for this bucket | `bool` | `true` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The KMS key ARN used for the bucket encryption | `string` | `null` | no |
 | <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | List of maps containing lifecycle management configuration settings | `any` | `[]` | no |
-| <a name="input_logging"></a> [logging](#input\_logging) | Logging configuration, logging is disabled by default | <pre>object({<br>    target_bucket = string<br>    target_prefix = string<br>  })</pre> | <pre>{<br>  "target_bucket": null,<br>  "target_prefix": "s3_access_logs/"<br>}</pre> | no |
+| <a name="input_logging"></a> [logging](#input\_logging) | Logging configuration, logging is disabled by default | <pre>object({<br>    target_bucket = string<br>    target_prefix = string<br>  })</pre> | `null` | no |
 | <a name="input_logging_source_bucket_arns"></a> [logging\_source\_bucket\_arns](#input\_logging\_source\_bucket\_arns) | Configures which source buckets are allowed to log to this bucket. | `list(string)` | `[]` | no |
 | <a name="input_object_lock_days"></a> [object\_lock\_days](#input\_object\_lock\_days) | The number of days that you want to specify for the default retention period | `number` | `null` | no |
 | <a name="input_object_lock_mode"></a> [object\_lock\_mode](#input\_object\_lock\_mode) | The default object Lock retention mode to apply to new objects | `string` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -68,10 +68,7 @@ variable "logging" {
     target_bucket = string
     target_prefix = string
   })
-  default = {
-    target_bucket = null
-    target_prefix = "s3_access_logs/"
-  }
+  default     = null
   description = "Logging configuration, logging is disabled by default"
 }
 


### PR DESCRIPTION
This PR simplifies the "logging" functionality.

In the past, by default S3 would log in it's own bucket. This has been disabled: https://github.com/schubergphilis/terraform-aws-mcaf-s3/pull/24

It indeed is a really bad idea I've experienced and with this PR it's disabled more explicitly. The `logging` definition is now `null` by default.

Reasoning to start with this is that we're encountering TF failures when deploying some new buckets, which is related to the "complex" logic. 

The error:

```cli
Error: Invalid for_each argument
on .terraform/modules/xxx_bucket/main.tf line 172, in resource "aws_s3_bucket_logging" "default":
  for_each      = local.logging
local.logging is a map of bool, known only after apply
The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so Terraform cannot determine the full set of keys that will identify the instances of this resource.

When working with unknown values in for_each, it's better to define the map keys statically in your configuration and place apply-time results only in the map values.

Alternatively, you could use the -target planning option to first apply only the resources that the for_each value depends on, and then apply a second time to fully converge.
```