### PR TITLE
fix: Always set the filter attribute of the lifecycle

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -313,6 +313,12 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
         }
       }
 
+      dynamic "filter" {
+        for_each = rule.value.filter == null ? { create = true } : {}
+
+        content {}
+      }
+
       # -------------------------------
       # noncurrent_version_expiration (max 1 block)
       # -------------------------------


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
This PR makes sure the `filter` attribute is always set on the [s3_bucket_lifecycle_configuration](https://registry.terraform.io/providers/-/aws/latest/docs/resources/s3_bucket_lifecycle_configuration). 

Either [`prefix`](https://registry.terraform.io/providers/-/aws/latest/docs/resources/s3_bucket_lifecycle_configuration#prefix-1) or [`filter`](https://registry.terraform.io/providers/-/aws/latest/docs/resources/s3_bucket_lifecycle_configuration#filter-1) has to be configured. Since `prefix` is marked as deprecated in short this means `filter` always has to be configured.

If no filter is needed, you specificy ["no filter" by applying an empty filter attribute](https://registry.terraform.io/providers/-/aws/latest/docs/resources/s3_bucket_lifecycle_configuration#specifying-an-empty-filter)

Currently this is a warning:

```log
Warning: Invalid Attribute Combination
with xxx.module.bucket.aws_s3_bucket_lifecycle_configuration.default[0]
on .terraform/modules/xxx.bucket/main.tf line 101, in resource "aws_s3_bucket_lifecycle_configuration" "default":
resource "aws_s3_bucket_lifecycle_configuration" "default" {
No attribute specified when one (and only one) of [rule[0].filter,rule[0].prefix] is required

This will be an error in a future version of the provider
```

**:rocket: Motivation**
<!-- Why is this change required? What problem does it solve? -->
With the way the code is created (with the variable), created it with a dynamic so it "automatically" is handled "as expected" and resolve the deprecation warning 

**:pencil: Additional Information**
<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to Confluence, Microsoft Docs, or images that may help with reviewing the PR. -->
