### PR TITLE
feature: Adds support to use access_control_policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -163,7 +163,7 @@ resource "aws_s3_bucket_acl" "default" {
   count = var.object_ownership_type == "ObjectWriter" ? 1 : 0
 
   bucket = aws_s3_bucket.default.id
-  acl    = var.acl
+  acl = var.use_acl ? var.acl : null
   dynamic "access_control_policy" {
     for_each = var.access_control_policy != null ? [var.access_control_policy] : []
 

--- a/main.tf
+++ b/main.tf
@@ -164,7 +164,26 @@ resource "aws_s3_bucket_acl" "default" {
 
   bucket = aws_s3_bucket.default.id
   acl    = var.acl
+  dynamic "access_control_policy" {
+    for_each = var.access_control_policy != null ? [var.access_control_policy] : [] # Only iterate if the variable is defined
 
+    content {
+      owner {
+        id = access_control_policy.value.owner.id # Dynamically access the values
+      }
+
+      grant {
+        for_each = access_control_policy.value.grants
+        content {
+          grantee {
+            type       = grant.value.grantee.type
+            identifier = grant.value.grantee.identifier
+          }
+          permission = grant.value.permission
+        }
+      }
+    }
+  }
   depends_on = [aws_s3_bucket_ownership_controls.default]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -163,7 +163,7 @@ resource "aws_s3_bucket_acl" "default" {
   count = var.object_ownership_type == "ObjectWriter" ? 1 : 0
 
   bucket = aws_s3_bucket.default.id
-  acl = var.use_acl ? var.acl : null
+  acl    = var.use_acl ? var.acl : null
   dynamic "access_control_policy" {
     for_each = var.access_control_policy != null ? [var.access_control_policy] : []
 
@@ -176,7 +176,7 @@ resource "aws_s3_bucket_acl" "default" {
         for_each = access_control_policy.value.grants
         content {
           grantee {
-            type       = grant.value.grantee.type
+            type          = grant.value.grantee.type
             id            = grant.value.grantee.type == "CanonicalUser" ? grant.value.grantee.identifier : null
             uri           = grant.value.grantee.type == "Group" ? grant.value.grantee.identifier : null
             email_address = grant.value.grantee.type == "AmazonCustomerByEmail" ? grant.value.grantee.identifier : null

--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,9 @@ resource "aws_s3_bucket_acl" "default" {
         content {
           grantee {
             type       = grant.value.grantee.type
-            id = grant.value.grantee.id
+            id            = grant.value.grantee.type == "CanonicalUser" ? grant.value.grantee.identifier : null
+            uri           = grant.value.grantee.type == "Group" ? grant.value.grantee.identifier : null
+            email_address = grant.value.grantee.type == "AmazonCustomerByEmail" ? grant.value.grantee.identifier : null
           }
           permission = grant.value.permission
         }

--- a/main.tf
+++ b/main.tf
@@ -163,7 +163,7 @@ resource "aws_s3_bucket_acl" "default" {
   count = var.object_ownership_type == "ObjectWriter" ? 1 : 0
 
   bucket = aws_s3_bucket.default.id
-  acl    = var.use_acl ? var.acl : null
+  acl    = acl = var.access_control_policy != null ? null : var.acl
   dynamic "access_control_policy" {
     for_each = var.access_control_policy != null ? [var.access_control_policy] : []
 

--- a/main.tf
+++ b/main.tf
@@ -169,7 +169,7 @@ resource "aws_s3_bucket_acl" "default" {
 
     content {
       owner {
-        id = access_control_policy.value.owner.id
+        id = access_control_policy.value.owner_id
       }
 
       dynamic "grant" {

--- a/main.tf
+++ b/main.tf
@@ -165,19 +165,19 @@ resource "aws_s3_bucket_acl" "default" {
   bucket = aws_s3_bucket.default.id
   acl    = var.acl
   dynamic "access_control_policy" {
-    for_each = var.access_control_policy != null ? [var.access_control_policy] : [] # Only iterate if the variable is defined
+    for_each = var.access_control_policy != null ? [var.access_control_policy] : []
 
     content {
       owner {
-        id = access_control_policy.value.owner.id # Dynamically access the values
+        id = access_control_policy.value.owner.id
       }
 
-      grant {
+      dynamic "grant" {
         for_each = access_control_policy.value.grants
         content {
           grantee {
             type       = grant.value.grantee.type
-            identifier = grant.value.grantee.identifier
+            id = grant.value.grantee.id
           }
           permission = grant.value.permission
         }

--- a/main.tf
+++ b/main.tf
@@ -163,7 +163,7 @@ resource "aws_s3_bucket_acl" "default" {
   count = var.object_ownership_type == "ObjectWriter" ? 1 : 0
 
   bucket = aws_s3_bucket.default.id
-  acl    = acl = var.access_control_policy != null ? null : var.acl
+  acl = var.access_control_policy != null ? null : var.acl
   dynamic "access_control_policy" {
     for_each = var.access_control_policy != null ? [var.access_control_policy] : []
 

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,17 @@ variable "access_control_policy" {
     }))
   })
 
+  validation {
+    condition = var.access_control_policy == null || alltrue([
+      for grant in var.access_control_policy.grants : (
+        grant.grantee.type == "CanonicalUser" || 
+        grant.grantee.type == "Group" || 
+        grant.grantee.type == "AmazonCustomerByEmail"
+      )
+    ])
+    error_message = "Every grantee 'type' in grants must be one of 'CanonicalUser', 'Group', or 'AmazonCustomerByEmail'."
+  }
+
   default = null # Making it optional
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -34,13 +34,13 @@ variable "access_control_policy" {
     grants = list(object({
       grantee = object({
         type       = string
-        identifier = string
+        id = string
       })
       permission = string
     }))
   })
 
-  default = null # Allow the policy to be optional
+  default = null # Making it optional
 }
 
 variable "block_public_acls" {

--- a/variables.tf
+++ b/variables.tf
@@ -39,8 +39,8 @@ variable "access_control_policy" {
     })
     grants = list(object({
       grantee = object({
-        type       = string
-        id = optional(string, null)
+        type       = string # Allowed values: "CanonicalUser", "Group", "AmazonCustomerByEmail"
+        identifier = optional(string, null) # Maps to id, uri, or email_address based on the grantee type
       })
       permission = string
     }))

--- a/variables.tf
+++ b/variables.tf
@@ -26,12 +26,6 @@ variable "acl" {
   description = "The canned ACL to apply, defaults to `private`."
 }
 
-variable "use_acl" {
-  description = "Whether to use canned ACL (true) or access_control_policy (false)"
-  type        = bool
-  default     = true
-}
-
 variable "access_control_policy" {
   type = object({
     owner_id = string

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,23 @@ variable "acl" {
   description = "The canned ACL to apply, defaults to `private`."
 }
 
+variable "access_control_policy" {
+  type = object({
+    owner = object({
+      id = string
+    })
+    grants = list(object({
+      grantee = object({
+        type       = string
+        identifier = string
+      })
+      permission = string
+    }))
+  })
+
+  default = null # Allow the policy to be optional
+}
+
 variable "block_public_acls" {
   type        = bool
   default     = true

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,12 @@ variable "acl" {
   description = "The canned ACL to apply, defaults to `private`."
 }
 
+variable "use_acl" {
+  description = "Whether to use canned ACL (true) or access_control_policy (false)"
+  type        = bool
+  default     = true
+}
+
 variable "access_control_policy" {
   type = object({
     owner = object({
@@ -34,7 +40,7 @@ variable "access_control_policy" {
     grants = list(object({
       grantee = object({
         type       = string
-        id = string
+        id = optional(string, null)
       })
       permission = string
     }))

--- a/variables.tf
+++ b/variables.tf
@@ -34,9 +34,7 @@ variable "use_acl" {
 
 variable "access_control_policy" {
   type = object({
-    owner = object({
-      id = string
-    })
+    owner_id = string
     grants = list(object({
       grantee = object({
         type       = string # Allowed values: "CanonicalUser", "Group", "AmazonCustomerByEmail"

--- a/variables.tf
+++ b/variables.tf
@@ -40,7 +40,7 @@ variable "access_control_policy" {
     grants = list(object({
       grantee = object({
         type       = string # Allowed values: "CanonicalUser", "Group", "AmazonCustomerByEmail"
-        identifier = optional(string, null) # Maps to id, uri, or email_address based on the grantee type
+        identifier = string # Maps to id, uri, or email_address based on the grantee type
       })
       permission = string
     }))


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
Adds the ability to  use access_control_policy to aws_s3_bucket_acl

**:rocket: Motivation**
Current implementation does not have access_control_policy as configurable

