### PR TITLE
fix: validation fails if access_control_policy is null

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -37,18 +37,20 @@ variable "access_control_policy" {
       permission = string
     }))
   })
-
   validation {
-    condition = var.access_control_policy == null || alltrue([
-      for grant in var.access_control_policy.grants : (
-        grant.grantee.type == "CanonicalUser" ||
-        grant.grantee.type == "Group" ||
-        grant.grantee.type == "AmazonCustomerByEmail"
+    condition = (
+      var.access_control_policy == null || (
+        alltrue([
+          for grant in(var.access_control_policy != null ? var.access_control_policy.grants : []) : (
+            grant.grantee.type == "CanonicalUser" ||
+            grant.grantee.type == "Group" ||
+            grant.grantee.type == "AmazonCustomerByEmail"
+          )
+        ])
       )
-    ])
+    )
     error_message = "Every grantee 'type' in grants must be one of 'CanonicalUser', 'Group', or 'AmazonCustomerByEmail'."
   }
-
   default = null
 }
 


### PR DESCRIPTION
the validation of the access_control_policy fails with it has the value of null with the error:

Error: Attempt to get attribute from null value on .terraform/modules/audit_logs_archive_bucket/variables.tf line 43, in variable "access_control_policy":
    43:       for grant in var.access_control_policy.grants : (
     ────────────────
    var.access_control_policy is null

This value is null, so it does not have any attributes.

Operation failed: failed running terraform plan (exit 1)

Rewriting the logic of the validation fixes this