### PR TITLE
fix: guard access_control_policy validation against null value

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,14 +19,14 @@ repos:
           - --allow-missing-credentials
       - id: detect-private-key
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.98.1
+    rev: v1.99.0
     hooks:
       - id: terraform_fmt
       - id: terraform_tflint
       - id: terraform_docs
       - id: terraform_validate
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.388
+    rev: 3.2.429
     hooks:
       - id: checkov
         verbose: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,14 +19,14 @@ repos:
           - --allow-missing-credentials
       - id: detect-private-key
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.99.0
+    rev: v1.98.1
     hooks:
       - id: terraform_fmt
       - id: terraform_tflint
       - id: terraform_docs
       - id: terraform_validate
   - repo: https://github.com/bridgecrewio/checkov.git
-    rev: 3.2.429
+    rev: 3.2.388
     hooks:
       - id: checkov
         verbose: false

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Or partitioned prefix, which uses the following format for the log file with par
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_access_control_policy"></a> [access\_control\_policy](#input\_access\_control\_policy) | n/a | <pre>object({<br/>    owner_id = string<br/>    grants = list(object({<br/>      grantee = object({<br/>        type       = string # Allowed values: "CanonicalUser", "Group", "AmazonCustomerByEmail"<br/>        identifier = string # Maps to id, uri, or email_address based on the grantee type<br/>      })<br/>      permission = string<br/>    }))<br/>  })</pre> | `null` | no |
+| <a name="input_access_control_policy"></a> [access\_control\_policy](#input\_access\_control\_policy) | The access control policy permissions for an S3 bucket object per grantee. | <pre>object({<br/>    owner_id = string<br/>    grants = list(object({<br/>      grantee = object({<br/>        type       = string # Allowed values: "CanonicalUser", "Group", "AmazonCustomerByEmail"<br/>        identifier = string # Maps to id, uri, or email_address based on the grantee type<br/>      })<br/>      permission = string<br/>    }))<br/>  })</pre> | `null` | no |
 | <a name="input_acl"></a> [acl](#input\_acl) | The canned ACL to apply, defaults to `private`. | `string` | `"private"` | no |
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for this bucket. | `bool` | `true` | no |
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Or partitioned prefix, which uses the following format for the log file with par
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.98.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Or partitioned prefix, which uses the following format for the log file with par
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.98.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70.0 |
 
 ## Modules
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -16,5 +16,5 @@ The following variables have been modified:
     - `noncurrent_version_transition` has changed from `map` to `list(object)`
     - `transition` has changed from `map` to `list(object)`
     - `prefix` has been moved to `filter.prefix` to be able to support all filter options
-    
+
 - `versioning`: default value has changed from `false` to `true`

--- a/main.tf
+++ b/main.tf
@@ -769,4 +769,3 @@ resource "aws_s3_bucket_versioning" "default" {
     status = var.versioning ? "Enabled" : "Suspended"
   }
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,8 @@ variable "access_control_policy" {
       permission = string
     }))
   })
+  default     = null
+  description = "The access control policy permissions for an S3 bucket object per grantee."
 
   validation {
     condition = (
@@ -52,8 +54,6 @@ variable "access_control_policy" {
     )
     error_message = "Every grantee 'type' in grants must be one of 'CanonicalUser', 'Group', or 'AmazonCustomerByEmail'."
   }
-
-  default = null
 }
 
 variable "block_public_acls" {

--- a/variables.tf
+++ b/variables.tf
@@ -39,13 +39,17 @@ variable "access_control_policy" {
   })
 
   validation {
-    condition = var.access_control_policy == null || alltrue([
-      for grant in var.access_control_policy.grants : (
-        grant.grantee.type == "CanonicalUser" ||
-        grant.grantee.type == "Group" ||
-        grant.grantee.type == "AmazonCustomerByEmail"
-      )
-    ])
+    condition = (
+      var.access_control_policy == null ?
+      true :
+      alltrue([
+        for grant in var.access_control_policy.grants : (
+          grant.grantee.type == "CanonicalUser" ||
+          grant.grantee.type == "Group" ||
+          grant.grantee.type == "AmazonCustomerByEmail"
+        )
+      ])
+    )
     error_message = "Every grantee 'type' in grants must be one of 'CanonicalUser', 'Group', or 'AmazonCustomerByEmail'."
   }
 


### PR DESCRIPTION
:hammer_and_wrench: Summary
This PR fixes a validation error when access_control_policy is null by guarding attribute access with a ternary check.

:rocket: Motivation
The issue came up when using this module inside a parent module. Running terraform validate failed because .grants was accessed even when access_control_policy was null. The fix ensures that .grants is only accessed when the variable isn't null, which avoids the error.