### PR TITLE
Fix/fix lifecycle filter handling

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -306,6 +306,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
       # --------------------------------------------------
       # filter (max 1 block)
       # --------------------------------------------------
+      
       dynamic "filter" {
         for_each = rule.value.filter != null ? [rule.value.filter] : []
 
@@ -339,7 +340,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
       dynamic "filter" {
         for_each = rule.value.filter == null ? { create = true } : {}
 
-        content {}
+        content { 
+          prefix = ""
+        }
       }
 
       # -------------------------------
@@ -774,4 +777,8 @@ resource "aws_s3_bucket_versioning" "default" {
   versioning_configuration {
     status = var.versioning ? "Enabled" : "Suspended"
   }
+}
+
+output "test" {
+  value = var.lifecycle_rule
 }

--- a/main.tf
+++ b/main.tf
@@ -306,7 +306,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
       # --------------------------------------------------
       # filter (max 1 block)
       # --------------------------------------------------
-      
       dynamic "filter" {
         for_each = rule.value.filter != null ? [rule.value.filter] : []
 
@@ -777,8 +776,4 @@ resource "aws_s3_bucket_versioning" "default" {
   versioning_configuration {
     status = var.versioning ? "Enabled" : "Suspended"
   }
-}
-
-output "test" {
-  value = var.lifecycle_rule
 }

--- a/variables.tf
+++ b/variables.tf
@@ -146,7 +146,7 @@ variable "lifecycle_rule" {
     }))
 
     filter = optional(object({
-      prefix                   = optional(string, "")
+      prefix                   = optional(string)
       object_size_greater_than = optional(number)
       object_size_less_than    = optional(number)
 
@@ -159,7 +159,7 @@ variable "lifecycle_rule" {
       and = optional(object({
         object_size_greater_than = optional(number)
         object_size_less_than    = optional(number)
-        prefix                   = optional(string, "")
+        prefix                   = optional(string)
         tags                     = optional(map(string))
       }))
     }))


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
PR should fix two warnings regarding filter section of life_cycle rule. 
As stated in AWS user documentation : If you want the S3 Lifecycle rule to apply to all objects in the bucket, specify an empty prefix. 
Also prefix values had a default in variables.tf but since they are optional defaults give issues, see : https://github.com/schubergphilis/terraform-aws-mcaf-s3/issues/60

**:rocket: Motivation**
Warning when planning creation of bucket without filter setting or with filter setting other than prefix. 

╷
│ Warning: Invalid Attribute Combination
│ 
│   with module.s3_bucket_backup_reports.aws_s3_bucket_lifecycle_configuration.default[0],
│   on ../../terraform-aws-mcaf-s3/main.tf line 268, in resource "aws_s3_bucket_lifecycle_configuration" "default":
│  268: resource "aws_s3_bucket_lifecycle_configuration" "default" {
│ 
│ 2 attributes specified when one (and only one) of
│ No attribute specified when one (and only one) of [rule[0].filter[0].prefix.<.object_size_greater_than,rule[0].filter[0].prefix.<.object_size_less_than,rule[0].filter[0].prefix.<.and,rule[0].filter[0].prefix.<.tag]
│ is required
│ 
│ This will be an error in a future version of the provider

Also: 
╷
│ Warning: Invalid Attribute Combination
│ 
│   with module.s3_bucket_backup_reports.aws_s3_bucket_lifecycle_configuration.default[0],
│   on ../../terraform-aws-mcaf-s3/main.tf line 268, in resource "aws_s3_bucket_lifecycle_configuration" "default":
│  268: resource "aws_s3_bucket_lifecycle_configuration" "default" {
│ 
│ 2 attributes specified when one (and only one) of
│ [rule[0].filter[0].prefix.<.object_size_greater_than,rule[0].filter[0].prefix.<.object_size_less_than,rule[0].filter[0].prefix.<.and,rule[0].filter[0].prefix.<.tag]
│ is required
│ 
│ This will be an error in a future version of the provider

This will be an error in a future version of the provider

**:pencil: Additional Information**

