### PR TITLE
fix: adding toggle to enforce default bucket key encryption on all ob…

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Or partitioned prefix, which uses the following format for the log file with par
 | [aws_s3_bucket_server_side_encryption_configuration.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_caller_identity.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.bucket_key_encryption_policy_enforced](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.logging_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.malware_protection_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -90,6 +91,7 @@ Or partitioned prefix, which uses the following format for the log file with par
 | <a name="input_acl"></a> [acl](#input\_acl) | The canned ACL to apply, defaults to `private`. | `string` | `"private"` | no |
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for this bucket. | `bool` | `true` | no |
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `true` | no |
+| <a name="input_bucket_key_encryption_enforced"></a> [bucket\_key\_encryption\_enforced](#input\_bucket\_key\_encryption\_enforced) | Enforces the default key encryption for all objects in the bucket | `bool` | `false` | no |
 | <a name="input_cors_rule"></a> [cors\_rule](#input\_cors\_rule) | The CORS rule for the S3 bucket | <pre>object({<br/>    allowed_headers = list(string)<br/>    allowed_methods = list(string)<br/>    allowed_origins = list(string)<br/>    expose_headers  = list(string)<br/>    max_age_seconds = number<br/>  })</pre> | `null` | no |
 | <a name="input_eventbridge_enabled"></a> [eventbridge\_enabled](#input\_eventbridge\_enabled) | Whether to enable Amazon EventBridge notifications. | `bool` | `false` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | A boolean that indicates all objects should be deleted when deleting the bucket. | `bool` | `false` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -319,3 +319,9 @@ variable "transition_default_minimum_object_size" {
     error_message = "Allowed values for transition_default_minimum_object_size are \"all_storage_classes_128K\", \"varies_by_storage_class\"."
   }
 }
+
+variable "bucket_key_encryption_enforced" {
+  type        = bool
+  default     = false
+  description = "Enforces the default key encryption for all objects in the bucket"
+}


### PR DESCRIPTION
Fixes https://github.com/schubergphilis/terraform-aws-mcaf-s3/issues/61

By setting the "bucket_key_encryption_enforced" variable to true only objects that are encrypted with the default bucket encryption key are allowed to upload.
