### PR TITLE
fix: improving validation on object lock settings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -445,6 +445,10 @@ resource "aws_s3_bucket_object_lock_configuration" "default" {
       condition     = var.object_lock_mode == null || length(var.logging_source_bucket_arns) == 0
       error_message = "You're trying to allow (other buckets) logging to this bucket and enable object locking on the same bucket! Object lock will prevent server access logs from written to the bucket. Either remove the logging source buckets configuration or remove the object lock configuration."
     }
+    precondition {
+      condition     = var.object_lock_mode == null || var.object_lock_days != null || var.object_lock_years != null
+      error_message = "When object_lock_mode is set, either object_lock_days or object_lock_years must also be set."
+    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -240,6 +240,15 @@ variable "object_lock_mode" {
   type        = string
   default     = null
   description = "The default object Lock retention mode to apply to new objects."
+
+  validation {
+    condition = (
+      var.object_lock_mode == null
+      ? true
+      : contains(["COMPLIANCE", "GOVERNANCE"], var.object_lock_mode)
+    )
+    error_message = "If set, object lock mode should be COMPLIANCE or GOVERNANCE"
+  }
 }
 
 variable "object_lock_years" {


### PR DESCRIPTION
Fixes this issue: https://github.com/schubergphilis/terraform-aws-mcaf-s3/issues/62

Improves the validation of object lock settings. The mode is checked against the 3 valid options (null, "GOVERNANCE" and "COMPLIANCE") and if the mode is set then either the days and/or the years must also be set.
