### PR TITLE
fix: Updated `data.aws_region.default` attribute due to depreciation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ Or partitioned prefix, which uses the following format for the log file with par
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   account_id            = data.aws_caller_identity.default.account_id
-  account_region        = data.aws_region.default.name
+  account_region        = data.aws_region.default.region
   logging_permissions   = length(var.logging_source_bucket_arns) > 0 ? { create = true } : {}
   malware_iam_role_name = aws_s3_bucket.default.id
   policy                = var.policy != null ? var.policy : null

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.70.0"
+      version = ">= 6.0.0"
     }
   }
 


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
With the release of AWS Provided 6.0.0. the resource `data "aws_region" "default" {}` has depricated its attribute `name`. the full replacement for this attribute is `region`. 

This PR will cover the deprecation.
<!--- A clear and concise description of what the PR entails. -->
<!-- Ex. I have added extra variables to be able to deploy [...] -->

**:rocket: Motivation**
<!-- Why is this change required? What problem does it solve? -->
Be inline with depriciations on provider level.

**:pencil: Additional Information**
<!-- If the proposed changes entail any design decisions, please provide any relevant background or references such as links to Confluence, Microsoft Docs, or images that may help with reviewing the PR. -->
-