### PR TITLE
feat!: Add region support

### DIFF
--- a/.github/workflows/terraform-test.yaml
+++ b/.github/workflows/terraform-test.yaml
@@ -1,0 +1,20 @@
+name: "terraform-test"
+
+on:
+  pull_request:
+
+jobs:
+  terraform-test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Task
+        uses: arduino/setup-task@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: Run unit tests
+        run: task test

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Or partitioned prefix, which uses the following format for the log file with par
 | [aws_iam_policy_document.s3_malware_protection_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_malware_protection_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ssl_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ Or partitioned prefix, which uses the following format for the log file with par
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
 
 ## Modules
 
@@ -82,7 +82,6 @@ Or partitioned prefix, which uses the following format for the log file with par
 | [aws_iam_policy_document.s3_malware_protection_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_malware_protection_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ssl_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_region.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -110,6 +109,7 @@ Or partitioned prefix, which uses the following format for the log file with par
 | <a name="input_object_lock_years"></a> [object\_lock\_years](#input\_object\_lock\_years) | The number of years that you want to specify for the default retention period. | `number` | `null` | no |
 | <a name="input_object_ownership_type"></a> [object\_ownership\_type](#input\_object\_ownership\_type) | The object ownership type for the objects in S3 Bucket, defaults to BucketOwnerEnforced. | `string` | `"BucketOwnerEnforced"` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | A valid bucket policy JSON document. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where the bucket will be created. If omitted, the default provider region is used. | `string` | `null` | no |
 | <a name="input_replication_configuration"></a> [replication\_configuration](#input\_replication\_configuration) | Bucket replication configuration settings, specify the rules map keys as integers as these are used to determine the priority of the rules in case of conflict. | <pre>object({<br/>    iam_role_arn = string<br/>    rules = map(object({<br/>      id                  = string<br/>      dest_bucket         = string<br/>      dest_storage_class  = optional(string, null)<br/>      replica_kms_key_arn = optional(string, null)<br/>      metrics = optional(object({<br/>        status                  = optional(bool, false)<br/>        event_threshold_minutes = optional(number, 15)<br/>      }))<br/>      replication_time = optional(object({<br/>        status       = optional(bool, false)<br/>        time_minutes = optional(number, 15)<br/>      }))<br/>      source_selection_criteria = optional(object({<br/>        replica_modifications     = optional(bool, false)<br/>        sse_kms_encrypted_objects = optional(bool, false)<br/>      }))<br/>    }))<br/>  })</pre> | `null` | no |
 | <a name="input_request_payer"></a> [request\_payer](#input\_request\_payer) | The request payer for the bucket, defaults to BucketOwner. Valid values: BucketOwner, Requester. | `string` | `"BucketOwner"` | no |
 | <a name="input_restrict_public_buckets"></a> [restrict\_public\_buckets](#input\_restrict\_public\_buckets) | Whether Amazon S3 should restrict public bucket policies for this bucket. | `bool` | `true` | no |

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,34 @@
+# https://taskfile.dev
+
+version: "3"
+
+env:
+  TF_IN_AUTOMATION: 1
+
+tasks:
+  default:
+    cmds:
+      - cmd: task --list
+        ignore_error: true
+    silent: true
+
+  clean:
+    desc: Clean lock files and cache directories
+    cmds:
+      - rm -rf .terraform.lock.hcl .terraform
+      - rm -rf **/.terraform.lock.hcl **/.terraform
+    silent: true
+
+  test:
+    desc: Run Terraform tests
+    cmds:
+      - terraform init
+      - terraform test
+    silent: true
+
+  verbose-test:
+    desc: Run verbose Terraform tests
+    cmds:
+      - terraform init
+      - terraform test -verbose
+    silent: true

--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,0 @@
-data "aws_caller_identity" "default" {}
-
-data "aws_region" "default" {}

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,5 @@
 locals {
   account_id            = data.aws_caller_identity.default.account_id
-  account_region        = data.aws_region.default.name
   logging_permissions   = length(var.logging_source_bucket_arns) > 0 ? { create = true } : {}
   malware_iam_role_name = aws_s3_bucket.default.id
   policy                = var.policy != null ? var.policy : null
@@ -17,11 +16,14 @@ locals {
   replication_configuration_enabled        = var.replication_configuration != null ? { create = true } : {}
 }
 
+data "aws_caller_identity" "default" {}
+
 ################################################################################
 # S3 Bucket & Bucket Policy
 ################################################################################
 
 resource "aws_s3_bucket" "default" {
+  region              = var.region
   bucket              = var.name
   bucket_prefix       = var.name_prefix
   force_destroy       = var.force_destroy
@@ -161,6 +163,7 @@ data "aws_iam_policy_document" "combined" {
 }
 
 resource "aws_s3_bucket_policy" "default" {
+  region = var.region
   bucket = aws_s3_bucket.default.id
   policy = data.aws_iam_policy_document.combined.json
 }
@@ -174,6 +177,7 @@ resource "aws_s3_bucket_policy" "default" {
 ###
 
 resource "aws_s3_bucket_ownership_controls" "default" {
+  region = var.region
   bucket = aws_s3_bucket.default.id
 
   rule {
@@ -184,6 +188,7 @@ resource "aws_s3_bucket_ownership_controls" "default" {
 resource "aws_s3_bucket_acl" "default" {
   count = var.object_ownership_type == "ObjectWriter" ? 1 : 0
 
+  region = var.region
   bucket = aws_s3_bucket.default.id
   acl    = var.access_control_policy != null ? null : var.acl
 
@@ -220,6 +225,7 @@ resource "aws_s3_bucket_acl" "default" {
 resource "aws_s3_bucket_cors_configuration" "default" {
   for_each = local.cors_rule_enabled
 
+  region = var.region
   bucket = aws_s3_bucket.default.bucket
 
   cors_rule {
@@ -238,6 +244,7 @@ resource "aws_s3_bucket_cors_configuration" "default" {
 resource "aws_s3_bucket_inventory" "default" {
   for_each = var.inventory_configuration
 
+  region                   = var.region
   bucket                   = aws_s3_bucket.default.id
   enabled                  = each.value.enabled
   included_object_versions = each.value.included_object_versions
@@ -291,6 +298,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
   #checkov:skip=CKV_AWS_300: Ensure S3 lifecycle configuration sets period for aborting failed uploads - consumer of the module should decide
   count = length(var.lifecycle_rule) > 0 ? 1 : 0
 
+  region                                 = var.region
   bucket                                 = aws_s3_bucket.default.bucket
   transition_default_minimum_object_size = var.transition_default_minimum_object_size
 
@@ -412,6 +420,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
 resource "aws_s3_bucket_logging" "default" {
   count = var.logging != null ? 1 : 0
 
+  region        = var.region
   bucket        = aws_s3_bucket.default.id
   target_bucket = var.logging.target_bucket
   target_prefix = var.logging.target_prefix
@@ -452,6 +461,7 @@ resource "aws_s3_bucket_logging" "default" {
 resource "aws_s3_bucket_object_lock_configuration" "default" {
   for_each = local.object_lock_enabled
 
+  region = var.region
   bucket = aws_s3_bucket.default.bucket
 
   rule {
@@ -481,7 +491,8 @@ resource "aws_s3_bucket_object_lock_configuration" "default" {
 resource "aws_guardduty_malware_protection_plan" "default" {
   for_each = local.malware_protection_enabled
 
-  role = module.s3_malware_protection_role["create"].arn
+  region = var.region
+  role   = module.s3_malware_protection_role["create"].arn
 
   protected_resource {
     s3_bucket {
@@ -515,7 +526,7 @@ data "aws_iam_policy_document" "s3_malware_protection_assume_role" {
     condition {
       test     = "ArnLike"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:guardduty:${local.account_region}:${local.account_id}:malware-protection-plan/*"]
+      values   = ["arn:aws:guardduty:${var.region}:${local.account_id}:malware-protection-plan/*"]
     }
   }
 }
@@ -533,7 +544,7 @@ data "aws_iam_policy_document" "s3_malware_protection_policy" {
       "events:RemoveTargets"
     ]
     resources = [
-      "arn:aws:events:${local.account_region}:${local.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:aws:events:${var.region}:${local.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
     condition {
       test     = "StringEquals"
@@ -550,7 +561,7 @@ data "aws_iam_policy_document" "s3_malware_protection_policy" {
       "events:ListTargetsByRule"
     ]
     resources = [
-      "arn:aws:events:${local.account_region}:${local.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:aws:events:${var.region}:${local.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
   }
 
@@ -651,7 +662,7 @@ data "aws_iam_policy_document" "s3_malware_protection_policy" {
       condition {
         test     = "StringLike"
         variable = "kms:ViaService"
-        values   = ["s3.${local.account_region}.amazonaws.com"]
+        values   = ["s3.${var.region}.amazonaws.com"]
       }
     }
   }
@@ -678,6 +689,7 @@ module "s3_malware_protection_role" {
 resource "aws_s3_bucket_notification" "eventbridge" {
   count = var.eventbridge_enabled ? 1 : 0
 
+  region      = var.region
   bucket      = aws_s3_bucket.default.id
   eventbridge = var.eventbridge_enabled
 }
@@ -689,6 +701,7 @@ resource "aws_s3_bucket_notification" "eventbridge" {
 resource "aws_s3_bucket_replication_configuration" "default" {
   for_each = local.replication_configuration_enabled
 
+  region = var.region
   role   = var.replication_configuration.iam_role_arn
   bucket = aws_s3_bucket.default.id
 
@@ -766,6 +779,7 @@ resource "aws_s3_bucket_replication_configuration" "default" {
 ###
 
 resource "aws_s3_bucket_request_payment_configuration" "default" {
+  region = var.region
   bucket = aws_s3_bucket.default.bucket
   payer  = var.request_payer
 }
@@ -775,6 +789,7 @@ resource "aws_s3_bucket_request_payment_configuration" "default" {
 ###
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
+  region = var.region
   bucket = aws_s3_bucket.default.bucket
 
   rule {
@@ -792,6 +807,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
 ###
 
 resource "aws_s3_bucket_public_access_block" "default" {
+  region                  = var.region
   bucket                  = aws_s3_bucket.default.id
   block_public_acls       = var.block_public_acls
   block_public_policy     = var.block_public_policy
@@ -804,6 +820,7 @@ resource "aws_s3_bucket_public_access_block" "default" {
 ###
 
 resource "aws_s3_bucket_versioning" "default" {
+  region = var.region
   bucket = aws_s3_bucket.default.id
 
   versioning_configuration {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
   account_id            = data.aws_caller_identity.default.account_id
+  account_region        = var.region != null ? var.region : data.aws_region.default.region
   logging_permissions   = length(var.logging_source_bucket_arns) > 0 ? { create = true } : {}
   malware_iam_role_name = aws_s3_bucket.default.id
   policy                = var.policy != null ? var.policy : null
@@ -18,12 +19,14 @@ locals {
 
 data "aws_caller_identity" "default" {}
 
+data "aws_region" "default" {}
+
 ################################################################################
 # S3 Bucket & Bucket Policy
 ################################################################################
 
 resource "aws_s3_bucket" "default" {
-  region              = var.region
+  region              = local.account_region
   bucket              = var.name
   bucket_prefix       = var.name_prefix
   force_destroy       = var.force_destroy
@@ -163,7 +166,7 @@ data "aws_iam_policy_document" "combined" {
 }
 
 resource "aws_s3_bucket_policy" "default" {
-  region = var.region
+  region = local.account_region
   bucket = aws_s3_bucket.default.id
   policy = data.aws_iam_policy_document.combined.json
 }
@@ -177,7 +180,7 @@ resource "aws_s3_bucket_policy" "default" {
 ###
 
 resource "aws_s3_bucket_ownership_controls" "default" {
-  region = var.region
+  region = local.account_region
   bucket = aws_s3_bucket.default.id
 
   rule {
@@ -188,7 +191,7 @@ resource "aws_s3_bucket_ownership_controls" "default" {
 resource "aws_s3_bucket_acl" "default" {
   count = var.object_ownership_type == "ObjectWriter" ? 1 : 0
 
-  region = var.region
+  region = local.account_region
   bucket = aws_s3_bucket.default.id
   acl    = var.access_control_policy != null ? null : var.acl
 
@@ -225,7 +228,7 @@ resource "aws_s3_bucket_acl" "default" {
 resource "aws_s3_bucket_cors_configuration" "default" {
   for_each = local.cors_rule_enabled
 
-  region = var.region
+  region = local.account_region
   bucket = aws_s3_bucket.default.bucket
 
   cors_rule {
@@ -244,7 +247,7 @@ resource "aws_s3_bucket_cors_configuration" "default" {
 resource "aws_s3_bucket_inventory" "default" {
   for_each = var.inventory_configuration
 
-  region                   = var.region
+  region                   = local.account_region
   bucket                   = aws_s3_bucket.default.id
   enabled                  = each.value.enabled
   included_object_versions = each.value.included_object_versions
@@ -298,7 +301,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
   #checkov:skip=CKV_AWS_300: Ensure S3 lifecycle configuration sets period for aborting failed uploads - consumer of the module should decide
   count = length(var.lifecycle_rule) > 0 ? 1 : 0
 
-  region                                 = var.region
+  region                                 = local.account_region
   bucket                                 = aws_s3_bucket.default.bucket
   transition_default_minimum_object_size = var.transition_default_minimum_object_size
 
@@ -420,7 +423,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "default" {
 resource "aws_s3_bucket_logging" "default" {
   count = var.logging != null ? 1 : 0
 
-  region        = var.region
+  region        = local.account_region
   bucket        = aws_s3_bucket.default.id
   target_bucket = var.logging.target_bucket
   target_prefix = var.logging.target_prefix
@@ -461,7 +464,7 @@ resource "aws_s3_bucket_logging" "default" {
 resource "aws_s3_bucket_object_lock_configuration" "default" {
   for_each = local.object_lock_enabled
 
-  region = var.region
+  region = local.account_region
   bucket = aws_s3_bucket.default.bucket
 
   rule {
@@ -491,7 +494,7 @@ resource "aws_s3_bucket_object_lock_configuration" "default" {
 resource "aws_guardduty_malware_protection_plan" "default" {
   for_each = local.malware_protection_enabled
 
-  region = var.region
+  region = local.account_region
   role   = module.s3_malware_protection_role["create"].arn
 
   protected_resource {
@@ -526,7 +529,7 @@ data "aws_iam_policy_document" "s3_malware_protection_assume_role" {
     condition {
       test     = "ArnLike"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:guardduty:${var.region}:${local.account_id}:malware-protection-plan/*"]
+      values   = ["arn:aws:guardduty:${local.account_region}:${local.account_id}:malware-protection-plan/*"]
     }
   }
 }
@@ -544,7 +547,7 @@ data "aws_iam_policy_document" "s3_malware_protection_policy" {
       "events:RemoveTargets"
     ]
     resources = [
-      "arn:aws:events:${var.region}:${local.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:aws:events:${local.account_region}:${local.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
     condition {
       test     = "StringEquals"
@@ -561,7 +564,7 @@ data "aws_iam_policy_document" "s3_malware_protection_policy" {
       "events:ListTargetsByRule"
     ]
     resources = [
-      "arn:aws:events:${var.region}:${local.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:aws:events:${local.account_region}:${local.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
   }
 
@@ -662,7 +665,7 @@ data "aws_iam_policy_document" "s3_malware_protection_policy" {
       condition {
         test     = "StringLike"
         variable = "kms:ViaService"
-        values   = ["s3.${var.region}.amazonaws.com"]
+        values   = ["s3.${local.account_region}.amazonaws.com"]
       }
     }
   }
@@ -689,7 +692,7 @@ module "s3_malware_protection_role" {
 resource "aws_s3_bucket_notification" "eventbridge" {
   count = var.eventbridge_enabled ? 1 : 0
 
-  region      = var.region
+  region      = local.account_region
   bucket      = aws_s3_bucket.default.id
   eventbridge = var.eventbridge_enabled
 }
@@ -701,7 +704,7 @@ resource "aws_s3_bucket_notification" "eventbridge" {
 resource "aws_s3_bucket_replication_configuration" "default" {
   for_each = local.replication_configuration_enabled
 
-  region = var.region
+  region = local.account_region
   role   = var.replication_configuration.iam_role_arn
   bucket = aws_s3_bucket.default.id
 
@@ -779,7 +782,7 @@ resource "aws_s3_bucket_replication_configuration" "default" {
 ###
 
 resource "aws_s3_bucket_request_payment_configuration" "default" {
-  region = var.region
+  region = local.account_region
   bucket = aws_s3_bucket.default.bucket
   payer  = var.request_payer
 }
@@ -789,7 +792,7 @@ resource "aws_s3_bucket_request_payment_configuration" "default" {
 ###
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
-  region = var.region
+  region = local.account_region
   bucket = aws_s3_bucket.default.bucket
 
   rule {
@@ -807,7 +810,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
 ###
 
 resource "aws_s3_bucket_public_access_block" "default" {
-  region                  = var.region
+  region                  = local.account_region
   bucket                  = aws_s3_bucket.default.id
   block_public_acls       = var.block_public_acls
   block_public_policy     = var.block_public_policy
@@ -820,7 +823,7 @@ resource "aws_s3_bucket_public_access_block" "default" {
 ###
 
 resource "aws_s3_bucket_versioning" "default" {
-  region = var.region
+  region = local.account_region
   bucket = aws_s3_bucket.default.id
 
   versioning_configuration {

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.70.0"
+      version = "~> 6.0"
     }
   }
 

--- a/tests/main.tftest.hcl
+++ b/tests/main.tftest.hcl
@@ -1,0 +1,91 @@
+# Mock aws provider, otherwise Terraform tries to connect to the service API.
+mock_provider "aws" {
+  # Mock data.aws_region: we always want to return "eu-central-1" for our tests.
+  mock_data "aws_region" {
+    defaults = {
+      region = "eu-central-1"
+    }
+  }
+}
+
+run "setup" {
+  module {
+    source = "./tests/setup"
+  }
+}
+
+# The default test checks logic in module when using it's default values when creating a plan.
+# Additional tests below check individual variables and changes to their defaults. Try not to
+# create assertions for resource fields that reference just the variable.
+run "default" {
+  command = plan
+
+  module {
+    source = "./"
+  }
+
+  assert {
+    condition     = aws_s3_bucket.default.region == "eu-central-1"
+    error_message = "Expected S3 bucket region to be eu-central-1, got: ${aws_s3_bucket.default.region}"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_ownership_controls.default.region == "eu-central-1"
+    error_message = "Expected S3 bucket ownership controls region to be eu-central-1, got: ${aws_s3_bucket_ownership_controls.default.region}"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_policy.default.region == "eu-central-1"
+    error_message = "Expected S3 bucket policy region to be eu-central-1, got: ${aws_s3_bucket_policy.default.region}"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_public_access_block.default.region == "eu-central-1"
+    error_message = "Expected S3 bucket public access block region to be eu-central-1, got: ${aws_s3_bucket_public_access_block.default.region}"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_request_payment_configuration.default.region == "eu-central-1"
+    error_message = "Expected S3 bucket request payment configuration region to be eu-central-1, got: ${aws_s3_bucket_request_payment_configuration.default.region}"
+  }
+}
+
+# Test resources use the supplied region value.
+# Without a specified region they should fall back to the aws_region data source (tested in default
+# test).
+run "region" {
+  command = plan
+
+  module {
+    source = "./"
+  }
+
+  variables {
+    region = "eu-west-1"
+  }
+
+  assert {
+    condition     = aws_s3_bucket.default.region == "eu-west-1"
+    error_message = "Expected S3 bucket region to be eu-west-1, got: ${aws_s3_bucket.default.region}"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_ownership_controls.default.region == "eu-west-1"
+    error_message = "Expected S3 bucket ownership controls region to be eu-west-1, got: ${aws_s3_bucket_ownership_controls.default.region}"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_policy.default.region == "eu-west-1"
+    error_message = "Expected S3 bucket policy region to be eu-west-1, got: ${aws_s3_bucket_policy.default.region}"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_public_access_block.default.region == "eu-west-1"
+    error_message = "Expected S3 bucket public access block region to be eu-west-1, got: ${aws_s3_bucket_public_access_block.default.region}"
+  }
+
+  assert {
+    condition     = aws_s3_bucket_request_payment_configuration.default.region == "eu-west-1"
+    error_message = "Expected S3 bucket request payment configuration region to be eu-west-1, got: ${aws_s3_bucket_request_payment_configuration.default.region}"
+  }
+}

--- a/tests/setup/main.tf
+++ b/tests/setup/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "3.5.1"
+    }
+  }
+}
+
+resource "random_string" "default" {
+  length  = 4
+  special = false
+  upper   = false
+}
+
+output "random_string" {
+  value = random_string.default.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -265,6 +265,12 @@ variable "policy" {
   description = "A valid bucket policy JSON document."
 }
 
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where the bucket will be created. If omitted, the default provider region is used."
+}
+
 variable "replication_configuration" {
   type = object({
     iam_role_arn = string
@@ -329,3 +335,4 @@ variable "versioning" {
   default     = true
   description = "Versioning is a means of keeping multiple variants of an object in the same bucket."
 }
+


### PR DESCRIPTION
⚠️ **This introduces a breaking change as it requires at least v6 of the AWS provider.** ⚠️

## :hammer_and_wrench: Summary

This pull request updates the S3 bucket Terraform module to support explicit region configuration and upgrades the AWS provider version. The main focus is on allowing users to specify the AWS region for all bucket-related resources, which improves multi-region compatibility and control. Additionally, some unused data sources are removed, and the AWS provider version is updated to the latest major version.

**Region configuration improvements:** 

* Added a new `region` variable in `variables.tf` to allow users to specify the AWS region for the bucket and related resources. If omitted, the default provider region is used.
* Updated all S3 bucket-related resources in `main.tf` (e.g., `aws_s3_bucket`, `aws_s3_bucket_policy`, `aws_s3_bucket_acl`, etc.) to accept and use the `region` variable. This ensures consistent resource creation in the specified region.
* Updated IAM policy ARNs and KMS conditions to use the `region` variable instead of the removed `account_region` local, ensuring that policies are region-aware.

**Provider and data source updates:**

* Upgraded the AWS provider version constraint in `terraform.tf` to require version `~> 6.0`, ensuring compatibility with the latest provider features and changes.
* Removed unused `aws_region` and `aws_caller_identity` data sources from `data.tf` to clean up the codebase.
* Adjusted local variables in `main.tf` to use the new `region` variable instead of the removed data sources.

## :rocket: Motivation

Adding `var.region` removes the need to instantiate multiple AWS provider instances for multi-region deployments and ensure compatibility with the latest AWS provider.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
