### PR TITLE
docs: Upgrading to v2

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,19 +2,27 @@
 
 This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
 
+## Upgrading to v2.0.0
+
+### Key Changes
+
+- This module now requires a minimum AWS provider version of 6.0 to support the `region` parameter. If you are using multiple AWS provider blocks, please read [migrating from multiple provider configurations](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/enhanced-region-support#migrating-from-multiple-provider-configurations).
+
 ## Upgrading to v1.0.0
 
 ### Key Changes
 
 - Versioning is now enabled by default to comply with [Security Hub control S3.14](https://docs.aws.amazon.com/securityhub/latest/userguide/s3-controls.html#s3-14).
 - The variable `lifecycle_rule` has been updated from type `any` to `list(object)`, and support has been added for all possible `filter` options.
+
 #### Variables
 
 The following variables have been modified:
 
 - `lifecycle_rule`:
-    - `noncurrent_version_transition` has changed from `map` to `list(object)`
-    - `transition` has changed from `map` to `list(object)`
-    - `prefix` has been moved to `filter.prefix` to be able to support all filter options
+
+  - `noncurrent_version_transition` has changed from `map` to `list(object)`
+  - `transition` has changed from `map` to `list(object)`
+  - `prefix` has been moved to `filter.prefix` to be able to support all filter options
 
 - `versioning`: default value has changed from `false` to `true`


### PR DESCRIPTION
## :hammer_and_wrench: Summary

This pull request updates the `UPGRADING.md` documentation to include instructions for upgrading to version 2.0.0 of the module. The main change is a new minimum AWS provider version requirement to support the `region` parameter.

**Upgrade instructions:**

* Added a new section for upgrading to v2.0.0, specifying that the module now requires AWS provider version 6.0 or higher to support the `region` parameter, and included a link to guidance on migrating from multiple provider configurations.

## :rocket: Motivation

Major version releases should come with an upgrade guide. In this case it is handy to share there there is a process to migrate from multiple (aliased) provider configurations to a single provider with the `region` parameter.