### PR TITLE
chore: allow for latest 0.x mcaf-role versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Or partitioned prefix, which uses the following format for the log file with par
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3_malware_protection_role"></a> [s3\_malware\_protection\_role](#module\_s3\_malware\_protection\_role) | schubergphilis/mcaf-role/aws | ~> 0.4.0 |
+| <a name="module_s3_malware_protection_role"></a> [s3\_malware\_protection\_role](#module\_s3\_malware\_protection\_role) | schubergphilis/mcaf-role/aws | ~> 0.4 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -675,7 +675,7 @@ module "s3_malware_protection_role" {
   for_each = local.malware_protection_enabled
 
   source  = "schubergphilis/mcaf-role/aws"
-  version = "~> 0.4.0"
+  version = "~> 0.4"
 
   name                 = local.malware_iam_role_name
   assume_policy        = data.aws_iam_policy_document.s3_malware_protection_assume_role["create"].json


### PR DESCRIPTION
:hammer_and_wrench: Summary

Relaxed the version constraint for schubergphilis/mcaf-role/aws from ~> 0.4.0 to ~> 0.4 to allow newer 0.x versions.

:rocket: Motivation

Makes it easier to get updates and fixes from newer minor releases without being locked to 0.4.x.

:pencil: Additional Information

N/A