### PR TITLE
feat!: Add blocked_encryption_types variable with SSE-C default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ Or partitioned prefix, which uses the following format for the log file with par
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.40.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.40.0 |
 
 ## Modules
 
@@ -92,6 +92,7 @@ Or partitioned prefix, which uses the following format for the log file with par
 | <a name="input_acl"></a> [acl](#input\_acl) | The canned ACL to apply, defaults to `private`. | `string` | `"private"` | no |
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for this bucket. | `bool` | `true` | no |
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `true` | no |
+| <a name="input_blocked_encryption_types"></a> [blocked\_encryption\_types](#input\_blocked\_encryption\_types) | List of encryption types to block for S3 bucket objects. Valid values: `NONE` (unblocks all encryption types), `SSE-C` (blocks SSE-C encrypted uploads). | `list(string)` | <pre>[<br/>  "SSE-C"<br/>]</pre> | no |
 | <a name="input_bucket_key_encryption_enforced"></a> [bucket\_key\_encryption\_enforced](#input\_bucket\_key\_encryption\_enforced) | Enforces the default key encryption for all objects in the bucket | `bool` | `false` | no |
 | <a name="input_cors_rule"></a> [cors\_rule](#input\_cors\_rule) | The CORS rule for the S3 bucket | <pre>object({<br/>    allowed_headers = list(string)<br/>    allowed_methods = list(string)<br/>    allowed_origins = list(string)<br/>    expose_headers  = list(string)<br/>    max_age_seconds = number<br/>  })</pre> | `null` | no |
 | <a name="input_eventbridge_enabled"></a> [eventbridge\_enabled](#input\_eventbridge\_enabled) | Whether to enable Amazon EventBridge notifications. | `bool` | `false` | no |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,20 @@
 
 This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
 
+## Upgrading to v3.0.0
+
+### Key Changes
+
+- A new variable `blocked_encryption_types` has been added to control which encryption types are blocked for S3 bucket objects.
+- Starting in March 2026, Amazon S3 automatically blocks SSE-C uploads for all new buckets. To align with this behaviour, the default value is set to `["SSE-C"]`.
+- For existing buckets that previously had `blocked_encryption_types` set to `null` in the remote state, you will need to explicitly set `blocked_encryption_types = ["NONE"]` to preserve the previous behaviour.
+
+#### Variables
+
+The following variables have been added:
+
+- `blocked_encryption_types`: defaults to `["SSE-C"]`
+
 ## Upgrading to v2.0.0
 
 ### Key Changes

--- a/main.tf
+++ b/main.tf
@@ -796,7 +796,8 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "default" {
   bucket = aws_s3_bucket.default.bucket
 
   rule {
-    bucket_key_enabled = local.bucket_key_enabled
+    blocked_encryption_types = var.blocked_encryption_types
+    bucket_key_enabled       = local.bucket_key_enabled
 
     apply_server_side_encryption_by_default {
       kms_master_key_id = var.kms_key_arn

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,9 +2,9 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = ">= 6.40.0"
     }
   }
 
-  required_version = ">= 1.4.0"
+  required_version = ">= 1.6.0"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,17 @@ variable "block_public_policy" {
   description = "Whether Amazon S3 should block public bucket policies for this bucket."
 }
 
+variable "blocked_encryption_types" {
+  type        = list(string)
+  default     = ["SSE-C"]
+  description = "List of encryption types to block for S3 bucket objects. Valid values: `NONE` (unblocks all encryption types), `SSE-C` (blocks SSE-C encrypted uploads)."
+
+  validation {
+    condition     = alltrue([for v in var.blocked_encryption_types : contains(["NONE", "SSE-C"], v)])
+    error_message = "Valid values for blocked_encryption_types are \"NONE\" and \"SSE-C\"."
+  }
+}
+
 variable "bucket_key_encryption_enforced" {
   type        = bool
   default     = false


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Add a new `blocked_encryption_types` variable to the `aws_s3_bucket_server_side_encryption_configuration` resource, defaulting to ["SSE-C"].

## :rocket: Motivation

A recent AWS provider update introduced the `blocked_encryption_types` attribute, causing unexpected plan diffs (https://github.com/hashicorp/terraform-provider-aws/issues/47320) on existing buckets. Additionally, since March 2026 Amazon S3 automatically blocks SSE-C uploads for new buckets. This change explicitly manages the attribute to prevent unwanted diffs and aligns the module default with AWS's new behaviour.